### PR TITLE
Spark operator helm chart moved to kubeflow

### DIFF
--- a/source/lib/cdk_infra/eks_base_app.py
+++ b/source/lib/cdk_infra/eks_base_app.py
@@ -68,7 +68,7 @@ class EksBaseAppConst(Construct):
         # Add Spark Operator to EKS
         eks_cluster.add_helm_chart('SparkOperatorChart',
             chart='spark-operator',
-            repository='https://googlecloudplatform.github.io/spark-on-k8s-operator',
+            repository='https://kubeflow.github.io/spark-operator',
             release='spark-operator',
             version='1.1.27',
             create_namespace=True,

--- a/source/setup.py
+++ b/source/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
         "aws-cdk-lib==2.105.0",
         "aws-cdk.lambda-layer-kubectl-v27==2.1.0",
         "constructs>=10.0.0,<11.0.0",
-        "pyyaml==5.4"
+        "pyyaml==6.0.1"
     ],
 
     python_requires=">=3.7",


### PR DESCRIPTION
refer to the [github issue](https://github.com/kubeflow/spark-operator/issues/1953), Spark Operator helm chart repo URL is changed to kubeflow. 

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
